### PR TITLE
Fixed potential divide by zero error

### DIFF
--- a/FHIRBulkImport/ImportUtils.cs
+++ b/FHIRBulkImport/ImportUtils.cs
@@ -72,7 +72,7 @@ namespace FHIRBulkImport
                 string msg = $"ImportFHIRBundles: FHIR Service Call Completed for bundle {name}{sresourcecnt}in {timefhir.ElapsedMilliseconds} ms";
                 if (resourcecnt > 0)
                 {
-                    double effrate = resourcecnt / (timefhir.ElapsedMilliseconds * 1000d);
+                    double effrate = resourcecnt / (timefhir.ElapsedMilliseconds / 1000d);
                     msg = msg + " Effective Rate: " + string.Format("{0:F1}", effrate) + " resources/sec";
                 }
                 log.LogInformation(msg);

--- a/FHIRBulkImport/ImportUtils.cs
+++ b/FHIRBulkImport/ImportUtils.cs
@@ -72,7 +72,7 @@ namespace FHIRBulkImport
                 string msg = $"ImportFHIRBundles: FHIR Service Call Completed for bundle {name}{sresourcecnt}in {timefhir.ElapsedMilliseconds} ms";
                 if (resourcecnt > 0)
                 {
-                    double effrate = resourcecnt / (timefhir.ElapsedMilliseconds / 1000);
+                    double effrate = resourcecnt / (timefhir.ElapsedMilliseconds * 1000d);
                     msg = msg + " Effective Rate: " + string.Format("{0:F1}", effrate) + " resources/sec";
                 }
                 log.LogInformation(msg);


### PR DESCRIPTION
This fixes issue: https://github.com/microsoft/fhir-loader/issues/23

If the FHIR request is completed in less than 1000 milliseconds, then the conversion would return zero seconds. This causes a divide-by-zero error. I modified the divisor to a double so it will perform a floating point calculation instead of an integer calculation. 