### PR TITLE
Fix export output size error

### DIFF
--- a/FHIRBulkImport/ExportAllOrchestrator.cs
+++ b/FHIRBulkImport/ExportAllOrchestrator.cs
@@ -149,14 +149,11 @@ namespace FHIRBulkImport
                 }
 
                 // Attempt to add output array - untested.
-                retVal["output"] = new JArray();
-                foreach (var item in fileTracker)
+                // Putting every file in the array was too large. Durable functions have a max payload size of 16KB. After about 50 files it started throwing errors.
+                // Adding the url of the first exported file as a sample url, the other files can be found based on it.
+                if (fileTracker.Count > 0)
                 {
-                    var fileInfo = new JObject();
-                    fileInfo["type"] = options.ResourceType;
-                    fileInfo["url"] = item.Key;
-                    fileInfo["count"] = item.Value;
-                    ((JArray)retVal["output"]).Add(fileInfo);
+                    retVal["exportFilesSampleUrl"] = fileTracker.First().Key;
                 }
 
                 // Update durable function status

--- a/FHIRBulkImport/ImportNDJSONQueue.cs
+++ b/FHIRBulkImport/ImportNDJSONQueue.cs
@@ -19,7 +19,7 @@ namespace FHIRBulkImport
             string url = (string)blobCreatedEvent["data"]["url"];
             if (queueMessage.DequeueCount > 1)
             {
-                log.LogInformation($"ImportNDJSONQueue: Ignoring long running requeue of file {url}");
+                log.LogInformation($"ImportNDJSONQueue: Ignoring long running requeue of file {url} on dequeue {queueMessage.DequeueCount}");
                 return;
             }
             int maxresourcesperbundle = 200;


### PR DESCRIPTION
When updating the status message on export jobs the durable function has a max size of the status message of 16KB. This can be reached with about 50 files of output. To fix this detailed statuses of every output file have been removed from the job status.