### PR TITLE
updated the allowBlobPublicAccess property for storage account

### DIFF
--- a/scripts/fhirBulkImport.bicep
+++ b/scripts/fhirBulkImport.bicep
@@ -74,6 +74,9 @@ var prefixNameCleanShort = length(prefixNameClean) > 16 ? substring(prefixNameCl
 resource storageAccount 'Microsoft.Storage/storageAccounts@2021-08-01' = {
   name: '${prefixNameCleanShort}stor'
   location: location
+  properties: {
+    allowBlobPublicAccess: false
+  }
   sku: {
     name: 'Standard_LRS'
   }

--- a/scripts/fhirBulkImport.json
+++ b/scripts/fhirBulkImport.json
@@ -251,6 +251,9 @@
       "sku": {
         "name": "Standard_LRS"
       },
+      "properties": {
+          "allowBlobPublicAccess": false
+      },
       "kind": "StorageV2",
       "metadata": {
         "description": "Storage account used for loading files"


### PR DESCRIPTION
The issue #57 public access to blob container is addressed in this PR. The property allowBlobPublicAccess is being set to false as this will block the public access to storage account.

Testing:
1. Deployed the FHIR loader using ARM and bicep template.