### PR TITLE
Fixes for FHIR Loader ARM Template

### DIFF
--- a/scripts/createUiDefinition.json
+++ b/scripts/createUiDefinition.json
@@ -381,7 +381,7 @@
             "fhirServerUrl": "[steps('appSettings').fhirSection.fhirServerUrl]",
             "authenticationType": "[steps('appSettings').fhirAuthenticationSection.authenticationType]",
             "appServiceSize": "[steps('appSettings').functionAppConfigurationSection.appServiceSize]",
-            "serviceAccountClientId": "[steps('appSettings').fhirServicePrincipalSection.servicePrincipalSelector.objectId]",
+            "serviceAccountClientId": "[first(steps('appSettings').fhirServicePrincipalSection.servicePrincipalSelector.objectId)]",
             "serviceAccountSecret": "[steps('appSettings').fhirServicePrincipalSection.servicePrincipalSelector.password]",
             "fhirAudience": "[steps('advanced').advancedAudienceConfigurationSection.fhirAudienceTextBox]",
             "createRoleAssignment": "[steps('advanced').advancedRoleAssignmentConfigurationSection.roleAssignmentSelector]"

--- a/scripts/createUiDefinition.json
+++ b/scripts/createUiDefinition.json
@@ -325,66 +325,25 @@
                             }
                         ],
                         "visible": true
-                    },
-                    {
-                        "name": "advancedRoleAssignmentConfigurationSection",
-                        "type": "Microsoft.Common.Section",
-                        "label": "FHIR Role Assignment (optional)",
-                        "elements": [
-                            {
-                                "name": "roleAssignmentSelector",
-                                "type": "Microsoft.Common.DropDown",
-                                "label": "Create the role assignment for the function app to access the FHIR instance?",
-                                "defaultValue": "Yes",
-                                "multiselect": false,
-                                "selectAll": false,
-                                "defaultDescription": "Selecting 'No' will require you to manually create the role assignment.",
-                                "multiLine": true,
-                                "constraints": {
-                                    "allowedValues": [
-                                        {
-                                            "label": "Yes",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "label": "No",
-                                            "value": "false"
-                                        }
-                                    ],
-                                    "required": true
-                                },
-                                "visible": "[not(equals('FhirServer', steps('appSettings').fhirSection.fhirType))]"
-                            },
-                            {
-                                "name": "roleAssignmentInfoBox",
-                                "type": "Microsoft.Common.InfoBox",
-                                "visible": "[equals('false', steps('advanced').advancedRoleAssignmentConfigurationSection.roleAssignmentSelector)]",
-                                "options": {
-                                    "icon": "Warning",
-                                    "text": "You must create the role assignment manually before loading data with FHIR Loader Bulk Import."
-                                }
-                            }
-                        ],
-                        "visible": "[not(equals('FhirServer', steps('appSettings').fhirSection.fhirType))]"
                     }
                 ]
             }
         ],
-        "outputs": {
-            "prefix": "[basics('basicsConfigurationSection').resourcePrefix]",
-            "location": "[location()]",
-            "fhirType": "[steps('appSettings').fhirSection.fhirType]",
-			"fhirServiceId":"[steps('appSettings').fhirSection.fhirServiceSelector.id]",
-            "fhirServiceName": "[steps('appSettings').fhirSection.fhirServiceSelector.name]",
-            "apiForFhirId": "[steps('appSettings').fhirSection.apiForFhirSelector.id]",
-			"apiForFhirName": "[steps('appSettings').fhirSection.apiForFhirSelector.name]",
-            "fhirServerUrl": "[steps('appSettings').fhirSection.fhirServerUrl]",
-            "authenticationType": "[steps('appSettings').fhirAuthenticationSection.authenticationType]",
-            "appServiceSize": "[steps('appSettings').functionAppConfigurationSection.appServiceSize]",
-            "serviceAccountClientId": "[first(steps('appSettings').fhirServicePrincipalSection.servicePrincipalSelector.objectId)]",
-            "serviceAccountSecret": "[steps('appSettings').fhirServicePrincipalSection.servicePrincipalSelector.password]",
-            "fhirAudience": "[steps('advanced').advancedAudienceConfigurationSection.fhirAudienceTextBox]",
-            "createRoleAssignment": "[steps('advanced').advancedRoleAssignmentConfigurationSection.roleAssignmentSelector]"
-        }
+      "outputs": {
+        "prefix": "[basics('basicsConfigurationSection').resourcePrefix]",
+        "location": "[location()]",
+        "fhirType": "[steps('appSettings').fhirSection.fhirType]",
+        "fhirServiceId": "[steps('appSettings').fhirSection.fhirServiceSelector.id]",
+        "fhirServiceName": "[steps('appSettings').fhirSection.fhirServiceSelector.name]",
+        "apiForFhirId": "[steps('appSettings').fhirSection.apiForFhirSelector.id]",
+        "apiForFhirName": "[steps('appSettings').fhirSection.apiForFhirSelector.name]",
+        "fhirServerUrl": "[steps('appSettings').fhirSection.fhirServerUrl]",
+        "authenticationType": "[steps('appSettings').fhirAuthenticationSection.authenticationType]",
+        "appServiceSize": "[steps('appSettings').functionAppConfigurationSection.appServiceSize]",
+        "serviceAccountServicePrincipalId": "[first(steps('appSettings').fhirServicePrincipalSection.servicePrincipalSelector.objectId)]",
+        "serviceAccountClientId": "[steps('appSettings').fhirServicePrincipalSection.servicePrincipalSelector.appId]",
+        "serviceAccountSecret": "[steps('appSettings').fhirServicePrincipalSection.servicePrincipalSelector.password]",
+        "fhirAudience": "[steps('advanced').advancedAudienceConfigurationSection.fhirAudienceTextBox]"
+      }
     }
 }

--- a/scripts/deployFhirBulk.bash
+++ b/scripts/deployFhirBulk.bash
@@ -59,7 +59,7 @@ declare useExistingResourceGroup=""
 declare createNewResourceGroup=""
 declare resourceGroupLocation=""
 declare storageAccountNameSuffix="store"
-declare storageConnectionString=""
+declare storageAccountUri=""
 declare serviceplanSuffix="asp"
 declare redisAccountNameSuffix="cache"
 declare redisConnectionString=""
@@ -88,6 +88,7 @@ declare fhirServiceClientRoleAssignment=""
 # KeyVault 
 declare keyVaultName=""
 declare keyVaultExists=""
+declare keyVaultId=""
 declare useExistingKeyVault=""
 declare createNewKeyVault=""
 declare storeFHIRServiceConfig=""
@@ -106,12 +107,12 @@ declare deployPrefix=""
 declare stepresult=""
 declare bulkAppName=""
 declare defsubscriptionId=""
+declare userName=""
 declare subscriptionId=""
 declare resourceGroupName=""
 declare resourceGroupLocation=""
 declare bulkAppName=""
 declare deployPrefix=""
-declare storageConnectionString=""
 declare storesourceid=""
 declare stepresult=""
 declare keyVaultName=""
@@ -232,6 +233,7 @@ fi
 # set default subscription information
 #
 defsubscriptionId=$(az account show --query "id" --out json | sed 's/"//g') 
+userName=$(az account show --query user.name -o tsv)
 
 # Test for correct directory path / destination 
 #
@@ -373,6 +375,14 @@ if [[ -n "$keyVaultExists" ]]; then
 	echo "  "$keyVaultName" found"
 	echo " "
 	echo "Checking for FHIR Service configuration..."
+
+    keyVaultId=$(az keyvault show --name $keyVaultName --resource-group $resourceGroupName --query id --output tsv) 
+
+	# Assign the "Key Vault Secrets Officer" role to the service principal
+	az role assignment create --assignee $userName --role "Key Vault Secrets Officer" --scope $keyVaultId
+	echo "Assigned role Key Vault Secrets Officer to user..."
+	sleep 10
+
 	fhirServiceUrl=$(az keyvault secret show --vault-name $keyVaultName --name FS-URL --query "value" --out tsv 2>/dev/null)
 	if [ -n "$fhirServiceUrl" ]; then
 		echo "  FHIR Service URL: "$fhirServiceUrl
@@ -547,8 +557,12 @@ echo "Starting Deployments... "
         echo "Creating Key Vault ["$keyVaultName"] in location ["$resourceGroupName"]"
         set -x
         stepresult=$(az keyvault create --name $keyVaultName --resource-group $resourceGroupName --location  $resourceGroupLocation --tags $TAG --output none)
-		
-		sleep 3 ;
+		keyVaultId=$(az keyvault show --name $keyVaultName --resource-group $resourceGroupName --query id --output tsv) 
+
+		# Assign the "Key Vault Secrets Officer" role to the service principal
+		az role assignment create --assignee $userName --role "Key Vault Secrets Officer" --scope $keyVaultId
+
+		sleep 10 ;
     else
         echo "Using Existing Key Vault ["$keyVaultName"]"
     fi
@@ -575,30 +589,32 @@ echo "Creating FHIR Bulk Loader & Export Function Application"
 	# Create Storage Account
 	#
 	echo "Creating Storage Account ["$deployPrefix$storageAccountNameSuffix"]..."
-	stepresult=$(az storage account create --name $deployPrefix$storageAccountNameSuffix --resource-group $resourceGroupName --location  $resourceGroupLocation --sku $storageSKU --encryption-services blob --tags $TAG)
+	stepresult=$(az storage account create --name $deployPrefix$storageAccountNameSuffix --resource-group $resourceGroupName --location  $resourceGroupLocation --sku $storageSKU --encryption-services blob --tags $TAG --allow-shared-key-access false)
 
-	echo "Retrieving Storage Account Connection String..."
-	storageConnectionString=$(az storage account show-connection-string -g $resourceGroupName -n $deployPrefix$storageAccountNameSuffix --query "connectionString" --out tsv)
+	echo "Create Storage Account URI.."
+	storageAccountUri=$(az storage account show --name $deployPrefix$storageAccountNameSuffix --resource-group $resourceGroupName --query "primaryEndpoints.blob" --output tsv)
 	
-	echo "Storing Storage Account Connection String in Key Vault..."
-	stepresult=$(az keyvault secret set --vault-name $keyVaultName --name "FBI-STORAGEACCT" --value $storageConnectionString)
-	
+	storesourceid="/subscriptions/"$subscriptionId"/resourceGroups/"$resourceGroupName"/providers/Microsoft.Storage/storageAccounts/"$deployPrefix$storageAccountNameSuffix
+    stepresult=$(az role assignment create --role "Storage Blob Data Contributor" --assignee $userName --scope $storesourceid)
+	stepresult=$(az role assignment create --role "Storage Queue Data Contributor" --assignee $userName --scope $storesourceid)
+    sleep 30;
+
 	echo "Creating containers..."
 	echo "  Import bundles"
-	stepresult=$(az storage container create -n bundles --connection-string $storageConnectionString)
+	stepresult=$(az storage container create -n bundles --account-name $deployPrefix$storageAccountNameSuffix --auth-mode login)
 	echo "  Import ndjson"
-	stepresult=$(az storage container create -n ndjson --connection-string $storageConnectionString)
+	stepresult=$(az storage container create -n ndjson --account-name $deployPrefix$storageAccountNameSuffix --auth-mode login)
 	echo "  Import zip"
-	stepresult=$(az storage container create -n zip --connection-string $storageConnectionString)
+	stepresult=$(az storage container create -n zip --account-name $deployPrefix$storageAccountNameSuffix --auth-mode login)
 	echo "  Export"
-	stepresult=$(az storage container create -n export --connection-string $storageConnectionString)
+	stepresult=$(az storage container create -n export --account-name $deployPrefix$storageAccountNameSuffix --auth-mode login)
 	echo "  Export trigger"
-	stepresult=$(az storage container create -n export-trigger --connection-string $storageConnectionString)
+	stepresult=$(az storage container create -n export-trigger --account-name $deployPrefix$storageAccountNameSuffix --auth-mode login)
 	echo "Creating storage queues..."
 	echo "  Ndjson queue"
-	stepresult=$(az storage queue create -n ndjsonqueue --connection-string $storageConnectionString)
+	stepresult=$(az storage queue create -n ndjsonqueue --account-name $deployPrefix$storageAccountNameSuffix --auth-mode login)
 	echo "  Bundles queue"
-	stepresult=$(az storage queue create -n bundlequeue --connection-string $storageConnectionString)
+	stepresult=$(az storage queue create -n bundlequeue --account-name $deployPrefix$storageAccountNameSuffix --auth-mode login)
 	
 	# Create Service Plan
 	#
@@ -608,7 +624,7 @@ echo "Creating FHIR Bulk Loader & Export Function Application"
 	# Create the function app
 	echo "Creating FHIR Bulk Loader & Export Function App ["$bulkAppName"]..."
 	fahost=$(az functionapp create --name $bulkAppName --storage-account $deployPrefix$storageAccountNameSuffix  --plan $deployPrefix$serviceplanSuffix  --resource-group $resourceGroupName --runtime dotnet --os-type Windows --functions-version 4 --query "defaultHostName" --output tsv --only-show-errors)
-	stepresult=$(az functionapp config set --net-framework-version v6.0 --name $bulkAppName --resource-group $resourceGroupName)
+	stepresult=$(az functionapp config set --net-framework-version v8.0 --name $bulkAppName --resource-group $resourceGroupName)
 	stepresult=$(az functionapp update --name $bulkAppName --resource-group $resourceGroupName --set httpsOnly=true)
 	
 	# Result Echo
@@ -617,20 +633,27 @@ echo "Creating FHIR Bulk Loader & Export Function Application"
 	# Setup Auth 
 	echo "Creating MSI for FHIR Bulk Loader & Export Function App..."
 	msi=$(az functionapp identity assign -g $resourceGroupName -n $bulkAppName --query "principalId" --out tsv)
-	
-	# Setup Keyvault Access 
-	echo "Setting KeyVault Policy to allow secret access for FHIR Bulk Loader & Export App..."
-	stepresult=$(az keyvault set-policy -n $keyVaultName --secret-permissions list get set --object-id $msi)
+	sleep 30
 
+	# Setup Keyvault Role Assignment
+	keyVaultResourceId="/subscriptions/$subscriptionId/resourceGroups/$resourceGroupName/providers/Microsoft.KeyVault/vaults/$keyVaultName"
+	stepresult=$(az role assignment create --assignee "${msi}" --role "Key Vault Secrets Officer" --scope $keyVaultResourceId)
+
+	# Setup Role Assignment on function app
+	stepresult=$(az role assignment create --role "Storage Blob Data Contributor" --assignee "${msi}" --scope $storesourceid)
+	stepresult=$(az role assignment create --role "Storage Queue Data Contributor" --assignee "${msi}" --scope $storesourceid)
 	#If using MSI set fhir-proxy function app role assignment on FHIR Server
 	if [[ "$authType" == "MSI" ]] ; then 
 		echo "Setting "$fahost" app role assignment on FHIR Server..."
 		stepresult=$(retry az role assignment create --assignee "${msi}" --role "${msirolename}" --scope "${msifhirserverrid}" --only-show-errors)
 	fi
+
+	storageAccountQueueUri=$(az storage account show --name $deployPrefix$storageAccountNameSuffix --resource-group $resourceGroupName --query "primaryEndpoints.queue" --output tsv)
+
 	# Apply App Auth and Connection settings 
 	echo "Applying FHIR Bulk Loader & Export App settings ["$bulkAppName"]..."
 	echo " Fhir Service URL will be referenced directly in App Settings for readability"
-	stepresult=$(az functionapp config appsettings set --name $bulkAppName --resource-group $resourceGroupName --settings FBI-STORAGEACCT=$(kvuri FBI-STORAGEACCT) FS-URL=$fhirServiceUrl FS-TENANT-NAME=$(kvuri FS-TENANT-NAME) FS-CLIENT-ID=$(kvuri FS-CLIENT-ID) FS-SECRET=$(kvuri FS-SECRET) FS-RESOURCE=$(kvuri FS-RESOURCE) FS-ISMSI=$(kvuri FS-ISMSI))
+	stepresult=$(az functionapp config appsettings set --name $bulkAppName --resource-group $resourceGroupName --settings FBI-STORAGEACCT=$storageAccountUri FBI-STORAGEACCT-QUEUEURI-IDENTITY__queueServiceUri=$storageAccountQueueUri FBI-STORAGEACCT-QUEUEURI=$storageAccountQueueUri FUNCTIONS_INPROC_NET8_ENABLED=1 FBI-STORAGEACCT-IDENTITY__blobServiceUri=$storageAccountUri FS-URL=$fhirServiceUrl FS-TENANT-NAME=$(kvuri FS-TENANT-NAME) FS-CLIENT-ID=$(kvuri FS-CLIENT-ID) FS-SECRET=$(kvuri FS-SECRET) FS-RESOURCE=$(kvuri FS-RESOURCE) FS-ISMSI=$(kvuri FS-ISMSI) AzureWebJobsStorage__accountname=$deployPrefix$storageAccountNameSuffix)
 	
 	# Apply App Setting (static)
 	# Note:  We need to by default disable the ImportBlobTrigger as that will conflict with the EventGridTrigger
@@ -638,10 +661,13 @@ echo "Creating FHIR Bulk Loader & Export Function Application"
 	echo "Applying Static App settings for FHIR Bulk Loader & Export App ["$bulkAppName"]..."
 	stepresult=$(az functionapp config appsettings set --name $bulkAppName --resource-group $resourceGroupName --settings FBI-DISABLE-BLOBTRIGGER=1 FBI-DISABLE-HTTPEP=1 FBI-TRANSFORMBUNDLES=true FBI-POOLEDCON-MAXCONNECTIONS=20 AzureFunctionsJobHost__functionTimeout=23:00:00 FBI-POISONQUEUE-TIMER-CRON="0 */2 * * * *")
 
-
 	# Deploy Function Application code
 	echo "Deploying FHIR Bulk Loader & Export App from source repo to ["$bulkAppName"]...  note - this can take a while"
 	stepresult=$(retry az functionapp deployment source config --branch main --manual-integration --name $bulkAppName --repo-url https://github.com/microsoft/fhir-loader --resource-group $resourceGroupName)
+
+	echo "Deleting WebJobsStorageKey"
+	stepresult=$(az functionapp config appsettings delete --name $bulkAppName --resource-group $resourceGroupName --setting-names AzureWebJobsStorage)
+
 
 	sleep 30	
 	#---

--- a/scripts/fhirBulkImport.json
+++ b/scripts/fhirBulkImport.json
@@ -109,6 +109,13 @@
         "description": "If not using MSI, client ID of the service account used to connect to the FHIR Server"
       }
     },
+    "serviceAccountServicePrincipalId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "If not using MSI, service principal ID of the service account used to assign roles to connect to the FHIR Server"
+      }
+    },
     "serviceAccountSecret": {
       "type": "securestring",
       "defaultValue": "",
@@ -121,13 +128,6 @@
       "defaultValue": "",
       "metadata": {
         "description": "Audience used for FHIR Server tokens. Leave blank to use the FHIR url which will work for default FHIR deployments."
-      }
-    },
-    "createRoleAssignment": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "Automatically create a role assignment for the function app to access the FHIR service."
       }
     },
     "fhirContributorRoleAssignmentId": {
@@ -502,7 +502,6 @@
       }
     },
     {
-      "condition": "[equals(parameters('createRoleAssignment'), true())]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
       "name": "role-assign-fhir",
@@ -523,7 +522,7 @@
             "value": "[parameters('fhirContributorRoleAssignmentId')]"
           },
           "principalId": {
-            "value": "[reference(resourceId('Microsoft.Web/sites', format('{0}-func', variables('prefixNameCleanShort'))), '2021-03-01', 'full').identity.principalId]"
+            "value": "[if(equals(parameters('authenticationType'), 'servicePrincipal'), parameters('serviceAccountServicePrincipalId'), reference(resourceId('Microsoft.Web/sites', format('{0}-func', variables('prefixNameCleanShort'))), '2021-03-01', 'full').identity.principalId)]"
           }
         },
         "template": {


### PR DESCRIPTION
Description

1. The FHIR Loader ARM template for the Service Principal Selection has been fixed with modifications.
2. Added the role assignment that was lacking to the client app's principal ID.
3. Dropdown for "Role assignment" was removed due to changes in the FHIR Loader code. Assigning roles is required.

Related issues
user story [AB#123209](https://dev.azure.com/microsofthealth/Health/_backlogs/backlog/Embers/Stories/?workitem=123209)

Testing

Three scenarios are covered in the testing,

1. Service Principal with new client app registration
2. Service Principal with existing client app registration
3. MSI connection
